### PR TITLE
Add throttler dependency for documents service

### DIFF
--- a/apps/documents/Dockerfile
+++ b/apps/documents/Dockerfile
@@ -11,6 +11,7 @@ COPY tsconfig.json tsconfig.json
 COPY nest-cli.json nest-cli.json
 
 RUN npm install
+RUN npm install @nestjs/throttler
 
 COPY apps/documents apps/documents
 COPY libs libs

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/microservices": "^10.4.4",
     "@nestjs/platform-express": "^10.0.0",
-    "@nestjs/throttler": "^6.2.1",
     "@nestjs/typeorm": "^10.0.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",


### PR DESCRIPTION
Include the `@nestjs/throttler` package in the documents service to manage request throttling.